### PR TITLE
Fix persistent scoreboard title

### DIFF
--- a/src/main/java/cc/polyfrost/vanillahud/hud/Scoreboard.java
+++ b/src/main/java/cc/polyfrost/vanillahud/hud/Scoreboard.java
@@ -116,7 +116,7 @@ public class Scoreboard extends Config {
             boolean showRealScoreboard = objective != null;
             if (showRealScoreboard) {
                 Collection<Score> sortedScores = objective.getScoreboard().getSortedScores(objective);
-                showRealScoreboard = sortedScores.size() <= 15 && (sortedScores.size() > 0 || this.persistentTitle);
+                showRealScoreboard = sortedScores.size() <= 15 && (sortedScores.size() > 0 || (this.persistentTitle && this.scoreboardTitle));
             }
             return showRealScoreboard && super.shouldShow();
         }

--- a/src/main/java/cc/polyfrost/vanillahud/hud/Scoreboard.java
+++ b/src/main/java/cc/polyfrost/vanillahud/hud/Scoreboard.java
@@ -55,6 +55,11 @@ public class Scoreboard extends Config {
         )
         public boolean scoreboardTitle = true;
 
+        @Switch(
+                name = "Persistent Scoreboard Title"
+        )
+        public boolean persistentTitle = false;
+
         @Color(
                 name = "Title Background Color"
         )
@@ -111,7 +116,7 @@ public class Scoreboard extends Config {
             boolean showRealScoreboard = objective != null;
             if (showRealScoreboard) {
                 Collection<Score> sortedScores = objective.getScoreboard().getSortedScores(objective);
-                showRealScoreboard = sortedScores.size() <= 15 && sortedScores.size() > 0;
+                showRealScoreboard = sortedScores.size() <= 15 && (sortedScores.size() > 0 || this.persistentTitle);
             }
             return showRealScoreboard && super.shouldShow();
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In vanilla Minecraft, the scoreboard will only show the display name when there are 1-15 sorted scores. However, my original changes to the scoreboard only accounted for scores 15 or less. If there were 0, the scoreboard display name would appear. 

![image](https://user-images.githubusercontent.com/59412384/230516694-3cee00d5-9096-43b3-8a9a-9855d5d1ccce.png)

This PR corrects this mistake and will behave just like vanilla's scoreboard. This also should account for letting the HUD editor example preview show up when the 1-15 range check is not satisfied.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
There isn't any issue on GitHub reporting this.

## How to test
<!-- Provide steps to test this PR -->
You will need to find a server that allows you to set the sorted scores to 0, but keep the display name. Minemen Club (minemen.club) does allow this in their practice server using `/tsb`.

If there are no traces of the scoreboard rendering, and there is an example preview still when this criteria happens, you will know that this fix has been implemented correctly. If there is any different behavior I have not mentioned, let me know and I will investigate.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fixed an issue where the display name would persist when there are no scores.
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No