### PR TITLE
Fix: Boss Bar text position not respecting scale

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/hud/BossBar.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/BossBar.java
@@ -77,7 +77,7 @@ public class BossBar extends Config {
             this.drawHealth(this.getCompleteText(this.getText(example)), this.isBossActive() ? BossStatus.healthScale : 0.8f, 0, this.renderText ? 10 : 0);
             UGraphics.GL.popMatrix();
             if (this.renderText) {
-                super.draw(matrices, x + this.getWidth(1.0f, example) / 2 - (float) (fontRenderer.getStringWidth(this.getCompleteText(this.getText(example))) / 2), y, scale, example);
+                super.draw(matrices, x + this.getWidth(scale, example) / 2 - (float) (fontRenderer.getStringWidth(this.getCompleteText(this.getText(example))) / 2), y, scale, example);
             }
         }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixed an issue where the Boss Bar text position would not respect your scale.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issues listed in here. Found in https://discord.com/channels/822066990423605249/1177658026845544508/1177658026845544508

## How to test
<!-- Provide steps to test this PR -->
1. Ensure Boss Bar is enabled
2. Scale the Boss Bar's scale to something other than 1.0. The text should now remain centered instead of being shifted to where the 1.0 position would be.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fixed an issue where the Boss Bar text position would not respect your scale and be uncentered.
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No