### PR TITLE
Item Tooltip: Use vanilla shadow and position by default

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/VanillaHUD.java
+++ b/src/main/java/org/polyfrost/vanillahud/VanillaHUD.java
@@ -2,10 +2,7 @@ package org.polyfrost.vanillahud;
 
 import cc.polyfrost.oneconfig.utils.Notifications;
 import net.minecraftforge.fml.common.Loader;
-import org.polyfrost.vanillahud.hud.ActionBar;
-import org.polyfrost.vanillahud.hud.BossBar;
-import org.polyfrost.vanillahud.hud.Scoreboard;
-import org.polyfrost.vanillahud.hud.Title;
+import org.polyfrost.vanillahud.hud.*;
 
 @net.minecraftforge.fml.common.Mod(modid = VanillaHUD.MODID, name = VanillaHUD.NAME, version = VanillaHUD.VERSION)
 public class VanillaHUD {
@@ -15,7 +12,7 @@ public class VanillaHUD {
 
     public static ActionBar actionBar;
     public static BossBar bossBar;
-    //public static ItemTooltip itemTooltip;
+    public static ItemTooltip itemTooltip;
     public static Scoreboard scoreboard;
     public static Title title;
     public static boolean apec = false;
@@ -24,7 +21,7 @@ public class VanillaHUD {
     public void onFMLInitialization(net.minecraftforge.fml.common.event.FMLInitializationEvent event) {
         actionBar = new ActionBar();
         bossBar = new BossBar();
-        //itemTooltip = new ItemTooltip();
+        itemTooltip = new ItemTooltip();
         scoreboard = new Scoreboard();
         title = new Title();
     }

--- a/src/main/java/org/polyfrost/vanillahud/hud/ItemTooltip.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/ItemTooltip.java
@@ -34,7 +34,8 @@ public class ItemTooltip extends Config {
         private static final String EXAMPLE_TEXT = "Item Tooltip";
 
         public HeldItemTooltipHUD() {
-            super("", true, 1920f / 2, 1080f - 32f, 1, false, false, 0, 0, 0, new OneColor(0, 0, 0, 80), false, 2, new OneColor(0, 0, 0));
+            super("", true, 1920f / 2, 1080f - 37f, 1, false, false, 0, 0, 0, new OneColor(0, 0, 0, 80), false, 2, new OneColor(0, 0, 0));
+            this.textType = 1;
             EventManager.INSTANCE.register(this);
         }
 

--- a/src/main/java/org/polyfrost/vanillahud/mixin/GuiIngameForgeMixin.java
+++ b/src/main/java/org/polyfrost/vanillahud/mixin/GuiIngameForgeMixin.java
@@ -21,6 +21,6 @@ public class GuiIngameForgeMixin {
 
     @Inject(method = "renderToolHightlight", at = @At("HEAD"), cancellable = true)
     private void cancelHeldItem(CallbackInfo ci) {
-        //ci.cancel();
+        ci.cancel();
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Changed the default position to match Vanilla's
Changed the text shadow default to be enabled

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A - Mentioned on https://discord.com/channels/822066990423605249/1177802861506215986/1178147304151191692

## How to test
<!-- Provide steps to test this PR -->
1. Ensure you have the default config
2. For accuracy sakes, you will want to undo the cancellation of Vanilla's tooltip

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No