### PR TITLE
Fix: Boss Bar text position

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/hud/BossBar.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/BossBar.java
@@ -89,10 +89,10 @@ public class BossBar extends Config {
             UGraphics.GL.scale(scale, scale, 1);
             UGraphics.GL.translate(x / scale, y / scale, 1);
             this.drawHealth(this.getCompleteText(this.getText(example)), this.isBossActive() ? smoothHealth ? BossStatusHook.getPercent() : BossStatus.healthScale : 0.8f, 0, this.renderText ? 10 : 0);
-            UGraphics.GL.popMatrix();
             if (this.renderText) {
-                super.draw(matrices, x + this.getWidth(scale, example) / 2 - (float) (fontRenderer.getStringWidth(this.getCompleteText(this.getText(example))) / 2), y, scale, example);
+                super.draw(matrices, this.getWidth(1, example) / 2 - (float) (fontRenderer.getStringWidth(this.getCompleteText(this.getText(example))) / 2), 0, 1, example);
             }
+            UGraphics.GL.popMatrix();
         }
 
         @Override


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Took another attempt at fixing the bar position. My last attempt seemed to make it fix, just not as offensive for text that doesn't overlap the health bar.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://discord.com/channels/822066990423605249/1177658026845544508

## How to test
Make sure that you test both text that does and does not overlap.

Just scale the mod as you normally would.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fixed boss bar text shifting.
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No