### PR TITLE
add tab features

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
@@ -38,6 +38,16 @@ public class TabList extends Config {
             }
         });
         initialize();
+
+        addDependency("numberPing", "showPing");
+        addDependency("scalePing", "numberPing");
+        addDependency("hideFalsePing", "numberPing");
+        addDependency("pingLevelOne", "numberPing");
+        addDependency("pingLevelTwo", "numberPing");
+        addDependency("pingLevelThree", "numberPing");
+        addDependency("pingLevelFour", "numberPing");
+        addDependency("pingLevelFive", "numberPing");
+        addDependency("pingLevelSix", "numberPing");
     }
 
 
@@ -47,32 +57,31 @@ public class TabList extends Config {
             super(true, 1920 / 2f, 10);
         }
 
+        @Dropdown(
+                name = "Text Type",
+                options = {"No Shadow", "Shadow", "Full Shadow"}
+        )
+        public static int textType = 1;
+
         @Switch(
                 name = "Show Player's Head"
         )
         public static boolean showHead = true;
-
-        @Dropdown(
-                name = "Name Text Type",
-                options = {"No Shadow", "Shadow", "Full Shadow"}
-        )
-        public static int textType = 1;
 
         @Switch(
                 name = "Show Player's Ping"
         )
         public static boolean showPing = true;
 
-        @Dropdown(
-                name = "Ping Text Type",
-                options = {"No Shadow", "Shadow", "Full Shadow"}
+        @Switch(
+                name = "Use Number Ping"
         )
-        public static int pingType = 1;
+        public static boolean numberPing = true;
 
         @Switch(
                 name = "Scale Ping Text"
         )
-        public static boolean scalePingText = true;
+        public static boolean scalePing = true;
 
         @Switch(
                 name = "Hide False Ping",

--- a/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
@@ -50,7 +50,6 @@ public class TabList extends Config {
         addDependency("pingLevelSix", "numberPing");
     }
 
-
     public static class TabHud extends BasicHud {
 
         public TabHud() {
@@ -118,6 +117,11 @@ public class TabList extends Config {
                 name = "Ping Above 400"
         )
         public static OneColor pingLevelSix = new OneColor(-4318437);
+
+        @Color(
+                name = "Tab Widget Color"
+        )
+        public static OneColor tabWidgetColor = new OneColor(553648127);
 
         @Override
         protected void draw(UMatrixStack matrices, float x, float y, float scale, boolean example) {}

--- a/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
@@ -1,10 +1,8 @@
 package org.polyfrost.vanillahud.hud;
 
 import cc.polyfrost.oneconfig.config.Config;
-import cc.polyfrost.oneconfig.config.annotations.Dropdown;
-import cc.polyfrost.oneconfig.config.annotations.Exclude;
-import cc.polyfrost.oneconfig.config.annotations.HUD;
-import cc.polyfrost.oneconfig.config.annotations.Switch;
+import cc.polyfrost.oneconfig.config.annotations.*;
+import cc.polyfrost.oneconfig.config.core.OneColor;
 import cc.polyfrost.oneconfig.config.data.Mod;
 import cc.polyfrost.oneconfig.config.data.ModType;
 import cc.polyfrost.oneconfig.hud.BasicHud;
@@ -49,21 +47,68 @@ public class TabList extends Config {
             super(true, 1920 / 2f, 10);
         }
 
-        @Dropdown(
-                name = "Text Type",
-                options = {"No Shadow", "Shadow", "Full Shadow"}
-        )
-        public static int textType = 1;
-
         @Switch(
                 name = "Show Player's Head"
         )
         public static boolean showHead = true;
 
+        @Dropdown(
+                name = "Name Text Type",
+                options = {"No Shadow", "Shadow", "Full Shadow"}
+        )
+        public static int textType = 1;
+
         @Switch(
                 name = "Show Player's Ping"
         )
         public static boolean showPing = true;
+
+        @Dropdown(
+                name = "Ping Text Type",
+                options = {"No Shadow", "Shadow", "Full Shadow"}
+        )
+        public static int pingType = 1;
+
+        @Switch(
+                name = "Scale Ping Text"
+        )
+        public static boolean scalePingText = true;
+
+        @Switch(
+                name = "Hide False Ping",
+                description = "Hides falsified ping numbers such as a ping of 0 or 1 when on Hypixel"
+        )
+        public static boolean hideFalsePing = true;
+
+        @Color(
+                name = "Ping Between 0 and 75"
+        )
+        public static OneColor pingLevelOne = new OneColor(-15466667);
+
+        @Color(
+                name = "Ping Between 75 and 145"
+        )
+        public static OneColor pingLevelTwo = new OneColor(-14773218);
+
+        @Color(
+                name = "Ping Between 145 and 200"
+        )
+        public static OneColor pingLevelThree = new OneColor(-4733653);
+
+        @Color(
+                name = "Ping Between 200 and 300"
+        )
+        public static OneColor pingLevelFour = new OneColor(-13779);
+
+        @Color(
+                name = "Ping Between 300 and 400"
+        )
+        public static OneColor pingLevelFive = new OneColor(-6458098);
+
+        @Color(
+                name = "Ping Above 400"
+        )
+        public static OneColor pingLevelSix = new OneColor(-4318437);
 
         @Override
         protected void draw(UMatrixStack matrices, float x, float y, float scale, boolean example) {}

--- a/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
+++ b/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
@@ -27,7 +27,8 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 import java.util.List;
 
-@Mixin(GuiPlayerTabOverlay.class)
+// 1100 priority to load before Patcher
+@Mixin(value = GuiPlayerTabOverlay.class, priority = 1100)
 public class GuiPlayerTabOverlayMixin {
 
     @Shadow private IChatComponent header;
@@ -118,16 +119,10 @@ public class GuiPlayerTabOverlayMixin {
         Gui.drawScaledCustomSizeModalRect(x, y, u, v, uWidth, vHeight, width, height, tileWidth, tileHeight);
     }
 
-    /*
-        The following code has been taken from OverlayTweaks under the LGPLv3 License.
-        https://github.com/MicrocontrollersDev/OverlayTweaks/blob/1.20.4/LICENSE
-        It has been altered to support 1.8.9 and OneConfig, as well as general code cleanup.
-     */
-
     @Redirect(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;drawPing(IIILnet/minecraft/client/network/NetworkPlayerInfo;)V"))
     private void playerHead(GuiPlayerTabOverlay instance, int width, int x, int y, NetworkPlayerInfo networkPlayerInfoIn) {
         if (!TabList.TabHud.showPing) return;
-        if (!TabList.TabHud.numberPing) {
+        if (!TabList.TabHud.numberPing) { // in order to prevent blending issues we need to set the proper gl state
             GlStateManager.pushMatrix();
             GlStateManager.enableBlend();
             GlStateManager.enableAlpha();
@@ -160,5 +155,10 @@ public class GuiPlayerTabOverlayMixin {
         else if (ping >= 300 && ping < 400) color = TabList.TabHud.pingLevelFive;
         else if (ping >= 400) color = TabList.TabHud.pingLevelSix;
         return color;
+    }
+
+    @ModifyConstant(method = "renderPlayerlist", constant = @Constant(intValue = 553648127))
+    private int tabOpacity(int opacity) {
+        return TabList.TabHud.tabWidgetColor.getRGB();
     }
 }

--- a/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
+++ b/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
@@ -1,5 +1,6 @@
 package org.polyfrost.vanillahud.mixin;
 
+import cc.polyfrost.oneconfig.config.core.OneColor;
 import cc.polyfrost.oneconfig.internal.hud.HudCore;
 import cc.polyfrost.oneconfig.renderer.TextRenderer;
 import cc.polyfrost.oneconfig.utils.color.ColorUtils;
@@ -35,13 +36,12 @@ public class GuiPlayerTabOverlayMixin {
     @Unique private static final IChatComponent tab$exampleFooter = new ChatComponentText("VanillaHud");
 
     @Unique
-    int TRANSPARENT = ColorUtils.getColor(0, 0, 0, 0);
+    int tab$TRANSPARENT = ColorUtils.getColor(0, 0, 0, 0);
 
     @ModifyVariable(method = "renderPlayerlist", at = @At(value = "STORE", ordinal = 0), ordinal = 9)
     private int resetY(int y) {
         return 1;
     }
-
 
     @Redirect(method = "renderPlayerlist", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;header:Lnet/minecraft/util/IChatComponent;"))
     private IChatComponent modifyHeader(GuiPlayerTabOverlay instance) {
@@ -54,7 +54,6 @@ public class GuiPlayerTabOverlayMixin {
         if (HudCore.editing) return tab$exampleFooter;
         return footer;
     }
-
 
     @Inject(method = "renderPlayerlist", at = @At(value = "HEAD"))
     private void translate(int width, Scoreboard scoreboardIn, ScoreObjective scoreObjectiveIn, CallbackInfo ci) {
@@ -78,19 +77,19 @@ public class GuiPlayerTabOverlayMixin {
     @ModifyArgs(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;drawRect(IIIII)V", ordinal = 0))
     private void captureWidth(Args args) {
         TabList.hud.drawBG();
-        args.set(4, TRANSPARENT);
+        args.set(4, tab$TRANSPARENT);
         int width = new ScaledResolution(Minecraft.getMinecraft()).getScaledWidth() / 2;
         TabList.width = ((int) args.get(2) - width) * 2;
     }
 
     @ModifyArgs(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;drawRect(IIIII)V", ordinal = 1))
     private void cancelRect(Args args) {
-        args.set(4, TRANSPARENT);
+        args.set(4, tab$TRANSPARENT);
     }
 
     @ModifyArgs(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;drawRect(IIIII)V", ordinal = 3))
     private void captureHeight(Args args) {
-        args.set(4, TRANSPARENT);
+        args.set(4, tab$TRANSPARENT);
         TabList.height = args.get(3);
     }
 
@@ -119,18 +118,35 @@ public class GuiPlayerTabOverlayMixin {
         Gui.drawScaledCustomSizeModalRect(x, y, u, v, uWidth, vHeight, width, height, tileWidth, tileHeight);
     }
 
+    /*
+        The following code has been taken from OverlayTweaks under the LGPLv3 License.
+        https://github.com/MicrocontrollersDev/OverlayTweaks/blob/1.20.4/LICENSE
+        It has been altered to support 1.8.9 and OneConfig, as well as general code cleanup.
+     */
+
     @Redirect(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;drawPing(IIILnet/minecraft/client/network/NetworkPlayerInfo;)V"))
-    private void playerHead(GuiPlayerTabOverlay instance, int i, int j, int k, NetworkPlayerInfo networkPlayerInfoIn) {
+    private void playerHead(GuiPlayerTabOverlay instance, int width, int x, int y, NetworkPlayerInfo networkPlayerInfoIn) {
         if (!TabList.TabHud.showPing) return;
-        GlStateManager.pushMatrix();
-        GlStateManager.enableBlend();
-        GlStateManager.enableAlpha();
-        GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
-        GuiPlayerTabOverlayAccessor accessor = (GuiPlayerTabOverlayAccessor) instance;
-        accessor.renderPing(i, j, k, networkPlayerInfoIn);
-        GlStateManager.disableAlpha();
-        GlStateManager.disableBlend();
-        GlStateManager.popMatrix();
+        int ping = networkPlayerInfoIn.getResponseTime();
+        OneColor color = tab$getColor(ping);
+        String pingString = String.valueOf(ping);
+        if (TabList.TabHud.hideFalsePing && (ping <= 1 || ping >= 999)) pingString = "";
+        if (TabList.TabHud.scalePingText) {
+            GlStateManager.scale(0.5F, 0.5F, 0.5F);
+            TextRenderer.drawScaledString(pingString, 2 * (x + width) - Minecraft.getMinecraft().fontRendererObj.getStringWidth(String.valueOf(ping)) - 4, 2 * y + 4, color.getRGB(), TextRenderer.TextType.toType(TabList.TabHud.pingType), 1F);
+            GlStateManager.scale(2F, 2F, 2F);
+        } else TextRenderer.drawScaledString(pingString, x + width - Minecraft.getMinecraft().fontRendererObj.getStringWidth(String.valueOf(ping)), y, color.getRGB(), TextRenderer.TextType.toType(TabList.TabHud.pingType), 1F);
     }
 
+    @Unique
+    private static OneColor tab$getColor(int ping) {
+        OneColor color = new OneColor(-5636096);
+        if (ping >= 0 && ping < 75) color = TabList.TabHud.pingLevelOne;
+        else if (ping >= 75 && ping < 145) color = TabList.TabHud.pingLevelTwo;
+        else if (ping >= 145 && ping < 200) color = TabList.TabHud.pingLevelThree;
+        else if (ping >= 200 && ping < 300) color = TabList.TabHud.pingLevelFour;
+        else if (ping >= 300 && ping < 400) color = TabList.TabHud.pingLevelFive;
+        else if (ping >= 400) color = TabList.TabHud.pingLevelSix;
+        return color;
+    }
 }

--- a/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
+++ b/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
@@ -120,7 +120,7 @@ public class GuiPlayerTabOverlayMixin {
     }
 
     @Redirect(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;drawPing(IIILnet/minecraft/client/network/NetworkPlayerInfo;)V"))
-    private void playerHead(GuiPlayerTabOverlay instance, int width, int x, int y, NetworkPlayerInfo networkPlayerInfoIn) {
+    private void drawPing(GuiPlayerTabOverlay instance, int width, int x, int y, NetworkPlayerInfo networkPlayerInfoIn) {
         if (!TabList.TabHud.showPing) return;
         if (!TabList.TabHud.numberPing) { // in order to prevent blending issues we need to set the proper gl state
             GlStateManager.pushMatrix();

--- a/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
+++ b/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
@@ -127,15 +127,27 @@ public class GuiPlayerTabOverlayMixin {
     @Redirect(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiPlayerTabOverlay;drawPing(IIILnet/minecraft/client/network/NetworkPlayerInfo;)V"))
     private void playerHead(GuiPlayerTabOverlay instance, int width, int x, int y, NetworkPlayerInfo networkPlayerInfoIn) {
         if (!TabList.TabHud.showPing) return;
+        if (!TabList.TabHud.numberPing) {
+            GlStateManager.pushMatrix();
+            GlStateManager.enableBlend();
+            GlStateManager.enableAlpha();
+            GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
+            GuiPlayerTabOverlayAccessor accessor = (GuiPlayerTabOverlayAccessor) instance;
+            accessor.renderPing(width, x, y, networkPlayerInfoIn);
+            GlStateManager.disableAlpha();
+            GlStateManager.disableBlend();
+            GlStateManager.popMatrix();
+            return;
+        }
         int ping = networkPlayerInfoIn.getResponseTime();
         OneColor color = tab$getColor(ping);
         String pingString = String.valueOf(ping);
         if (TabList.TabHud.hideFalsePing && (ping <= 1 || ping >= 999)) pingString = "";
-        if (TabList.TabHud.scalePingText) {
+        if (TabList.TabHud.scalePing) {
             GlStateManager.scale(0.5F, 0.5F, 0.5F);
-            TextRenderer.drawScaledString(pingString, 2 * (x + width) - Minecraft.getMinecraft().fontRendererObj.getStringWidth(String.valueOf(ping)) - 4, 2 * y + 4, color.getRGB(), TextRenderer.TextType.toType(TabList.TabHud.pingType), 1F);
+            TextRenderer.drawScaledString(pingString, 2 * (x + width) - Minecraft.getMinecraft().fontRendererObj.getStringWidth(String.valueOf(ping)) - 4, 2 * y + 4, color.getRGB(), TextRenderer.TextType.toType(TabList.TabHud.textType), 1F);
             GlStateManager.scale(2F, 2F, 2F);
-        } else TextRenderer.drawScaledString(pingString, x + width - Minecraft.getMinecraft().fontRendererObj.getStringWidth(String.valueOf(ping)), y, color.getRGB(), TextRenderer.TextType.toType(TabList.TabHud.pingType), 1F);
+        } else TextRenderer.drawScaledString(pingString, x + width - Minecraft.getMinecraft().fontRendererObj.getStringWidth(String.valueOf(ping)), y, color.getRGB(), TextRenderer.TextType.toType(TabList.TabHud.textType), 1F);
     }
 
     @Unique


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ports tab features from my 1.20 mod [OverlayTweaks](https://github.com/MicrocontrollersDev/OverlayTweaks)
- number ping
- ping colors with 6 different ranges
- scale ping (scaled is how patcher does it, not scaled is how all other 1.20 ping mods do it)
- hide false ping (hides pings like 0 or 1 since servers like hypixel use these to hide ping)
- custom tab widget color

**ISSUES**:
- Dependencies don't work? Don't know why but I gotta go to class rn and I'm just gonna push this so someone else can figure out.
- Names of features aren't that great admittedly. Feel free to change or suggest better names.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
I asked on #tester-chat and Wyvest said yes

## How to test
<!-- Provide steps to test this PR -->
Log onto a server like Hypixel and press TAB

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
+ Added Number Ping
+ Added Ping Colors
+ Added Scaled Ping
+ Added Hide False Ping
+ Added Custom Tab Widget Color
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->