### PR TITLE
improve ping type by making it a dual option

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
@@ -77,10 +77,12 @@ public class TabList extends Config {
         )
         public static boolean numberPing = true;
 
-        @Switch(
-                name = "Scale Ping Text"
+        @DualOption(
+                name = "Ping Text",
+                left = "Small",
+                right = "Full"
         )
-        public static boolean scalePing = true;
+        public static boolean pingType = false;
 
         @Switch(
                 name = "Hide False Ping",

--- a/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
+++ b/src/main/java/org/polyfrost/vanillahud/mixin/GuiPlayerTabOverlayMixin.java
@@ -142,7 +142,7 @@ public class GuiPlayerTabOverlayMixin {
         OneColor color = tab$getColor(ping);
         String pingString = String.valueOf(ping);
         if (TabList.TabHud.hideFalsePing && (ping <= 1 || ping >= 999)) pingString = "";
-        if (TabList.TabHud.scalePing) {
+        if (!TabList.TabHud.pingType) {
             GlStateManager.scale(0.5F, 0.5F, 0.5F);
             TextRenderer.drawScaledString(pingString, 2 * (x + width) - Minecraft.getMinecraft().fontRendererObj.getStringWidth(String.valueOf(ping)) - 4, 2 * y + 4, color.getRGB(), TextRenderer.TextType.toType(TabList.TabHud.textType), 1F);
             GlStateManager.scale(2F, 2F, 2F);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Changes "Scale Ping" Switch to "Ping Text" DualOption. Personally I think this makes it a lot clearer what the option actually does.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
Open config and see if it does config stuff

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Change "Scale Ping" Switch to "Ping Text" DualOption
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->