### PR TITLE
Fixed a crash caused by a SkyHanni change

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_name = VanillaHUD
 mod_id = vanillahud
-mod_version = 2.2.11
+mod_version = 2.2.12
 mod_archives_name=VanillaHUD
 
 # Gradle Configuration -- DO NOT TOUCH THESE VALUES.

--- a/src/main/java/org/polyfrost/vanillahud/VanillaHUD.java
+++ b/src/main/java/org/polyfrost/vanillahud/VanillaHUD.java
@@ -2,6 +2,9 @@ package org.polyfrost.vanillahud;
 
 import Apec.Components.Gui.GuiIngame.ApecGuiIngameForge;
 import at.hannibal2.skyhanni.SkyHanniMod;
+import at.hannibal2.skyhanni.config.Features;
+import at.hannibal2.skyhanni.config.features.gui.customscoreboard.CustomScoreboardConfig;
+import at.hannibal2.skyhanni.config.features.misc.compacttablist.CompactTabListConfig;
 import at.hannibal2.skyhanni.features.misc.compacttablist.TabListReader;
 import at.hannibal2.skyhanni.utils.LorenzUtils;
 import cc.polyfrost.oneconfig.events.EventManager;
@@ -351,6 +354,21 @@ public class VanillaHUD {
             return Utils.inSkyblock;
         }
         if (!LorenzUtils.INSTANCE.getInSkyBlock()) return false;
+        try
+        {
+            Object gui = getSkyHanniGuiFeature();
+            Field compactTabListField = gui.getClass().getDeclaredField("compactTabList");
+            compactTabListField.setAccessible(true);
+            Object compactTabListObj = compactTabListField.get(gui);
+            if(compactTabListObj instanceof CompactTabListConfig) {
+                if (!((CompactTabListConfig)compactTabListObj).enabled.get()) return false;
+            }
+
+        }
+        catch (IllegalAccessException | NoSuchFieldException ignored)
+        {
+            //ignored, simply fall through and try the methods below
+        }
         if (skyHanniField) {
             if (!SkyHanniMod.feature.gui.compactTabList.enabled.get()) return false;
         } else {
@@ -365,11 +383,33 @@ public class VanillaHUD {
             return Utils.inSkyblock;
         }
         if (!LorenzUtils.INSTANCE.getInSkyBlock()) return false;
+        try
+        {
+            Object gui = getSkyHanniGuiFeature();
+            Field customScoreboardField = gui.getClass().getDeclaredField("customScoreboard");
+            customScoreboardField.setAccessible(true);
+            Object customScoreboardObj = customScoreboardField.get(gui);
+            if(customScoreboardObj instanceof CustomScoreboardConfig) {
+                if (!((CustomScoreboardConfig)customScoreboardObj).enabled.get()) return false;
+            }
+
+        }
+        catch (IllegalAccessException | NoSuchFieldException ignored)
+        {
+            //ignored, simply fall through and try the methods below
+        }
         if (skyHanniField) {
             return SkyHanniMod.feature.gui.customScoreboard.enabled.get();
         } else {
             return SkyHanniMod.getFeature().gui.customScoreboard.enabled.get();
         }
+    }
+
+    private static Object getSkyHanniGuiFeature() throws IllegalAccessException, NoSuchFieldException {
+        Features features = SkyHanniMod.feature;
+        Field guiField = features.getClass().getDeclaredField("gui");
+        guiField.setAccessible(true);
+        return guiField.get(features);
     }
 
     public static boolean isLegacyTablist() {

--- a/src/main/java/org/polyfrost/vanillahud/VanillaHUD.java
+++ b/src/main/java/org/polyfrost/vanillahud/VanillaHUD.java
@@ -386,7 +386,7 @@ public class VanillaHUD {
     private static boolean isSkyHanniCompactTab() {
         if (!isSkyHanni) return false;
         try {
-            if (Boolean.FALSE.equals(isSkyHanniCompactTabList())) return false;
+            if (!isSkyHanniCompactTabList()) return false;
         }
         catch (Throwable ignored) {
             //ignored, simply fall through and try the methods below
@@ -406,7 +406,7 @@ public class VanillaHUD {
     public static boolean isSkyHanniScoreboard() {
         if (!isSkyHanni) return false;
         try {
-            if (Boolean.FALSE.equals(isSkyHanniCustomScoreboard())) return false;
+            if (!isSkyHanniCustomScoreboard()) return false;
         }
         catch (Throwable ignored) {
             //ignored, simply fall through and try the methods below
@@ -434,19 +434,17 @@ public class VanillaHUD {
     }
 
     /**
-     * This method has 3 possible return values: true, false, null
+     * Returns if the Compact Tab List is enabled in the SkyHanni config
      * True = Compact Tab List is enabled
      * False = Compact Tab List is disabled
-     * Null = Couldn't get the config through method handles
      *
      * @return If the Compact Tab List is enabled in the SkyHanni config
      */
-    @Nullable
-    private static Boolean isSkyHanniCompactTabList() throws Throwable {
+    private static boolean isSkyHanniCompactTabList() throws Throwable {
         Object gui = getSkyHanniGuiFeature();
 
         if(gui == null || skyHanniGetCompactTabListHandle == null) {
-            return null;
+            throw new RuntimeException("Can't use the method handle for the SkyHanni Compact Tab List config.");
         }
 
         Object compactTabListObj = skyHanniGetCompactTabListHandle.invoke(gui);
@@ -455,24 +453,22 @@ public class VanillaHUD {
             return ((CompactTabListConfig) compactTabListObj).enabled.get();
         }
 
-        // If the method returns an invalid class, simply return null, the calling method should ignore this
-        return null;
+        // If the method returns an invalid class, the calling method should ignore this
+        throw new RuntimeException("The Compact Tab List config is not of the expected type - Try alternate methods");
     }
 
     /**
-     * This method has 3 possible return values: true, false, null
+     * Returns if the Custom Scoreboard is enabled in the SkyHanni config
      * True = Custom Scoreboard is enabled
      * False = Custom Scoreboard is disabled
-     * Null = Couldn't get the config through method handles
      *
      * @return If the Custom Scoreboard is enabled in the SkyHanni config
      */
-    @Nullable
-    private static Boolean isSkyHanniCustomScoreboard() throws Throwable {
+    private static boolean isSkyHanniCustomScoreboard() throws Throwable {
         Object gui = getSkyHanniGuiFeature();
 
         if(gui == null || skyHanniGetCustomScoreboardHandle == null) {
-            return null;
+            throw new RuntimeException("Can't use the method handle for the SkyHanni Custom Scoreboard config.");
         }
 
         Object customScoreboardObj = skyHanniGetCustomScoreboardHandle.invoke(gui);
@@ -481,8 +477,8 @@ public class VanillaHUD {
             return ((CustomScoreboardConfig) customScoreboardObj).enabled.get();
         }
 
-        // If the method returns an invalid class, simply return null, the calling method should ignore this
-        return null;
+        // If the method returns an invalid class, the calling method should ignore this
+        throw new RuntimeException("The Custom Scoreboard config is not of the expected type - Try alternate methods");
     }
 
     public static boolean isLegacyTablist() {


### PR DESCRIPTION
## Description
In the latest SkyHanni Beta version, a class has been renamed from GUIConfig to GuiConfig.
This causes a java.lang.NoSuchFieldError when VanillaHUD tries to access a field of that class.
Due to this change and the underlying structure (in /dummy), reflection has to be used, with a fallback to the old method.

## Related Issue(s)
There are none.

## How to test
- Use a SkyHanni Beta version >= 2.11.0 (or the latest Full Release 3.0.0)
- Join Hypixel
- Join Skyblock
- (not sure which config is needed, maybe the Compact Tab List has to be active)

## Release Notes
```release-note
- Fixed a crash when using this mod with SkyHanni installed
```

## Documentation
No