### PR TITLE
Remove grammar error in tablist warning

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/TabList.java
@@ -168,7 +168,7 @@ public class TabList extends HudConfig {
         public static OneColor tabWidgetColor = new OneColor(553648127);
 
         @Info(
-                text = "Tablist might goes over screen",
+                text = "Tablist might go over screen",
                 type = InfoType.WARNING
         )
         private static Runnable info = () -> { }; //runnable so it wont be saved


### PR DESCRIPTION
## Description
Changes the warning that says, "Tablist might goes over screen" to say "Tablist might go over screen".

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
Go to oneconfig, then vanillahud, then tab list. See that the text is not in the correct grammatical form.

## Release Notes
Fix grammatical error where the incorrect present form was used in a tab list configuration warning

## Documentation
No Documentation changes are required