### PR TITLE
Fix "Action Bar" being rendered before server sends actual action bar

### DIFF
--- a/src/main/java/org/polyfrost/vanillahud/hud/ActionBar.java
+++ b/src/main/java/org/polyfrost/vanillahud/hud/ActionBar.java
@@ -98,7 +98,7 @@ public class ActionBar extends HudConfig {
         protected String getText(boolean example) {
             GuiIngameAccessor ingameGUI = (GuiIngameAccessor) UMinecraft.getMinecraft().ingameGUI;
 
-            if (ingameGUI == null || ingameGUI.getRecordPlaying() == null || ingameGUI.getRecordPlaying().isEmpty() || !this.shouldShow() && example) {
+            if (example && (ingameGUI == null || ingameGUI.getRecordPlaying() == null || ingameGUI.getRecordPlaying().isEmpty() || !this.shouldShow())) {
                 this.opacity = 255;
                 return EXAMPLE_TEXT;
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Issue was caused by no paranthesis () in the condition - this meant && example section of the condition was interpreted as .. || (!this.shouldShow && example) basically, meanwhile it shouldve been (.. || !this.shouldShow()) && example.

I have also moved the example check to be the first thing checked in the if - avoids method calls if example wasn't true to start with, no idea if any of those methods have a performance impact, but still a good idea to check for the example boolean first before doing checks that call methods that might be more expensive than a simple boolean variable check.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
1. With upstream version without the patch from PR, join Hypixel while closely watching the Action Bar. It will say "Action Bar" for about 1-2 seconds before server sends a real action bar and then it will go away or be replaced with the actual action bar (e.g "Your online status is currently set to APPEARING OFFLINE" or whatever Hypixel sends)
2. (Optional additional testing) Type /oneconfig and click Edit HUDs and check what action bar says. If the server has sent you an action bar, itll display that, otherwise "Action Bar" default example text.
3. Apply patch from PR, rebuild gradle, put jar to mods folder, redo step 1 and you will no longer see the  "Action Bar" text instead it will only be shown when server sends an actual action bar.
3. (Optional additional testing) Type /oneconfig and click Edit HUDs and check what action bar says. If the server has sent you an action bar, itll display that, otherwise "Action Bar" default example text.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fix: "Action Bar" being rendered in action bar even before server sends an actual action bar
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A